### PR TITLE
chore: update intellij project files

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+antares

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -16,7 +16,6 @@
           </compositeBuild>
         </compositeConfiguration>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleHome" value="$PROJECT_DIR$/../../gradle-7.3" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.1.0" />
+    <option name="version" value="2.2.21" />
   </component>
 </project>


### PR DESCRIPTION
## Summary
- remove the project-specific Gradle home override from IntelliJ settings
- sync the tracked Kotlin plugin version metadata
- add the shared IntelliJ project name file

## Notes
- no source changes
- no build/test rerun needed for this metadata-only change